### PR TITLE
Update wp3_preprocessing_inbox.yaml

### DIFF
--- a/actions/workflows/wp3_preprocessing_inbox.yaml
+++ b/actions/workflows/wp3_preprocessing_inbox.yaml
@@ -32,7 +32,7 @@ workflows:
                 on-success:
                     - dos2unix
                 on-error:
-                    - mark_as_failed
+                    - mark_as_finished
 
             dos2unix:
                 action: core.local


### PR DESCRIPTION
Don't trigger unnecessary WP3 error message because of TM samples. TE and TM are using the same runfolder directory and WP3 gets triggered by "RTAComplete.txt" file, so when no TE sample is found in the SampleSheet.csv, make it silent and do not trigger any WP3 error message.