### PR TITLE
refactor: move method part to config

### DIFF
--- a/actions/workflows/retrieve_result_wp.yaml
+++ b/actions/workflows/retrieve_result_wp.yaml
@@ -141,18 +141,18 @@ tasks:
   create_year_folder:
     action: core.local
     input:
-      cwd: <% ctx(result_settings).get(ctx(workpackage)).get(ctx(method)).get('storage_prefix') %>/<% ctx(method) %>
+      cwd: <% ctx(result_settings).get(ctx(workpackage)).get(ctx(method)).get('storage_location') %>
       cmd: mkdir -p NGS_Resultat/<% ctx(run_year) %>
     next:
       - when: <% succeeded() %>
         publish: 
-          - result_storage_folder: <% ctx(result_settings).get(ctx(workpackage)).get(ctx(method)).get('storage_prefix') %>/<% ctx(method) %>/NGS_Resultat/<% ctx(run_year) %>
+          - result_storage_folder: <% ctx(result_settings).get(ctx(workpackage)).get(ctx(method)).get('storage_location') %>/NGS_Resultat/<% ctx(run_year) %>
         do:
           - transfer_result
       - when: <% failed() %>
         publish:
           - stderr: <% result().stderr %>
-          - failed_step: 'create_year_folder  -- Could not create folder <% ctx(result_settings).get(ctx(workpackage)).get(ctx(method)).get("storage_prefix") %>/<% ctx(method) %>/NGS_Resultat/<% ctx(run_year) %>'
+          - failed_step: 'create_year_folder  -- Could not create folder <% ctx(result_settings).get(ctx(workpackage)).get(ctx(method)).get("storage_location") %>/NGS_Resultat/<% ctx(run_year) %>'
         do:
           - bioinfo_error_notifier
           - error_notifier
@@ -186,18 +186,18 @@ tasks:
   create_qc_year_folder:
     action: core.local
     input:
-      cwd: <% ctx(result_settings).get(ctx(workpackage)).get(ctx(method)).get('storage_prefix') %>/<% ctx(method) %>
+      cwd: <% ctx(result_settings).get(ctx(workpackage)).get(ctx(method)).get('storage_location') %>
       cmd: mkdir -p batchQC/<% ctx(run_year) %>
     next:
       - when: <% succeeded() %>
         publish: 
-          - result_qc_storage_folder: <% ctx(result_settings).get(ctx(workpackage)).get(ctx(method)).get('storage_prefix') %>/<% ctx(method) %>/batchQC/<% ctx(run_year) %>
+          - result_qc_storage_folder: <% ctx(result_settings).get(ctx(workpackage)).get(ctx(method)).get('storage_location') %>/batchQC/<% ctx(run_year) %>
         do:
           - mv_qc_folder
       - when: <% failed() %>
         publish:
           - stderr: <% result().stderr %>
-          - failed_step: 'create_qc_year_folder -- Could not create year folder <% ctx(result_settings).get(ctx(workpackage)).get(ctx(method)).get("storage_prefix") %>/<% ctx(method) %>/batchQC/<% ctx(run_year) %>'
+          - failed_step: 'create_qc_year_folder -- Could not create year folder <% ctx(result_settings).get(ctx(workpackage)).get(ctx(method)).get("storage_location") %>/batchQC/<% ctx(run_year) %>'
         do:
           - bioinfo_error_notifier
           - mark_as_failed


### PR DESCRIPTION
make it possible to have storage without method, by setting it in the config. Preferably method ought to be included.