### PR TITLE
chore: Publish samplesheet to e mail

### DIFF
--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -177,7 +177,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][INFO] - Sample sheet , <% ctx(runfolder_name) %>"
-      body: The following content was found in sample sheet <% ctx(runfolder) %>/<% ctx(samplesheet_file) %>\n <% ctx(sample _sheet) %>
+      body: The following content was found in sample sheet <% ctx(runfolder) %>/<% ctx(samplesheet_file) %>\n <% ctx(samplesheet_content) %>
     next:
       - when: <% succeeded() %> or <% failed() %>
         do:

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -47,6 +47,7 @@ vars:
   - samples: null
   - stderr: null
   - machine_name: null
+  - samplesheet_content: null
 
 tasks:
   setting_runfolder:
@@ -145,7 +146,7 @@ tasks:
       - when: <% succeeded() %>
         publish: runfolder_name=<% result().stdout %>
         do:
-          - archive_sav_files
+          - get_samplesheet_content
       - when: <% failed() %>
         publish:
           - stderr: <% result() %>

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -178,7 +178,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][INFO] - Sample sheet , <% ctx(runfolder_name) %>"
-      body: The following content was found in sample sheet <% ctx(runfolder) %>/<% ctx(samplesheet_file) %>\n <% ctx(samplesheet_content) %>
+      body: The following content was found in sample sheet <% ctx(samplesheet_file) %>\n <% ctx(samplesheet_content) %>
     next:
       - when: <% succeeded() %> or <% failed() %>
         do:

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -178,6 +178,8 @@ tasks:
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][INFO] - Sample sheet , <% ctx(runfolder_name) %>"
       body: The following content was found in sample sheet <% ctx(runfolder) %>/<% ctx(samplesheet_file) %>\n <% ctx(sample _sheet) %>
+    next:
+      - when: <% succeeded() %> or <% failed() %>
         do:
           - archive_sav_files
   

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -153,6 +153,33 @@ tasks:
         do:
           - bioinfo_error_notifier
           - mark_as_failed
+
+  get_samplesheet_content:
+    action: core.local
+    input:
+      cmd: cat <% ctx(samplesheet_file) %>
+    next:
+      - when: <% succeeded() %>
+        publish: samplesheet_content=<% result().stdout %>
+        do:
+          - bioinfo_samplesheet_notifier
+      - when: <% failed() %>
+        publish:
+          - stderr: <% result() %>
+          - failed_step: "get_samplesheet_content  -- Couldn't get content from <% ctx(samplesheet_file) %> in folder <% ctx(runfolder_name) %>, "
+        do:
+          - bioinfo_error_notifier
+          - mark_as_failed
+
+  bioinfo_samplesheet_notifier:
+    action: core.sendmail
+    input:
+      to: <% ctx(mail_bioinfo) %>
+      from: stanley@clinicalgenomics-as.se
+      subject: "[DUCTUS][WP][INFO] - Sample sheet , <% ctx(runfolder_name) %>"
+      body: The following content was found in sample sheet <% ctx(runfolder) %>/<% ctx(samplesheet_file) %>\n <% ctx(sample _sheet) %>
+        do:
+          - archive_sav_files
   
   archive_sav_files:
     action: ductus.archive_interop_files


### PR DESCRIPTION
New feature added to workflow ductus.populate_processing_api_with_sequencerun with two new tasks:
- get_samplesheet_content, that will print the content of the bioinformatic sample sheet to a variable.
- bioinfo_samplesheet_notifier, that will use the variable from the previous task and send it as an e-mail to the bioinformaticans.

Testing:
- Code only tested in local docker container.