### PR TITLE
feat: increase timeouts in run_analysis

### DIFF
--- a/actions/workflows/run_analysis.yaml
+++ b/actions/workflows/run_analysis.yaml
@@ -101,7 +101,7 @@ tasks:
       hosts: <% ctx(process_host) %>
       cwd: <% ctx(analysis_folder_path) %>
       cmd: bash <% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('run_script') %> --inbox-path <% ctx(runfolder) %> <% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('parameters') %>
-      timeout: <% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('timeout', 178200) %>
+      timeout: <% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('timeout', 259200) %>
       hosts: <% ctx(process_host) %>
     next:
       - when: <% succeeded() and ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('outbox_files_and_folders', null) %>
@@ -229,7 +229,7 @@ tasks:
     input:
       cwd: <% ctx(analysis_folder_path) %>
       cmd: cp -r <% item() %> <% ctx(outbox_folder) %>/
-      timeout: 7200
+      timeout: 18000
     next:
       - when: <% succeeded() %>
         do:


### PR DESCRIPTION
1.) Increase the run_analysis timeout to 72 hours due to timeout issue with whole genome analyses

2.) Increase the syncing to outbox to 18000 (5 hours) as the transfer time of 2 hours could be too short for whole genome results, cutoff chosen based on  previously observed time of ~11600 seconds from rsyncing a wp3_hg run with 24 samples back to the outbox on marvin.