### PR TITLE
feat: CGUO-2253 filter sequence runs using samplesheet

### DIFF
--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -203,7 +203,7 @@ tasks:
   filter_experiment_samplesheet:
     action: core.local
     input:
-      cmd: python3 -c 'from ductus.tools.utils import filter_experiment; exit(0) if  filter_experiment("<% ctx(samplesheet_content)%>") == False else exit(1)'
+      cmd: python3 -c 'from ductus.tools.utils import filter_experiment; exit(0) if  filter_experiment("<% ctx(samplesheet_file)%>") == False else exit(1)'
     next:
       - when: <% succeeded() %>
         do:

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -191,7 +191,7 @@ tasks:
     next:
       - when: <% succeeded() %>
         do:
-          - detect_old_samplesheet_format
+          - filter_experiment_samplesheet
       - when: <% failed() %>
         publish:
           - stderr: <% result() %>
@@ -199,6 +199,33 @@ tasks:
         do:
           - bioinfo_error_notifier
           - mark_as_failed
+
+  filter_experiment_samplesheet:
+    action: core.local
+    input:
+      cmd: python3 -c 'from ductus.tools.utils import filter_experiment; exit(0) if  filter_experiment("<% ctx(samplesheet_content)%>") == False else exit(1)'
+    next:
+      - when: <% succeeded() %>
+        do:
+          - detect_old_samplesheet_format
+      - when: <% failed() %>
+        publish:
+          - stderr: <% result() %>
+          - failed_step: "filter_experiment_samplesheet -- The following run contains one or several experiments that can't be processed, <% ctx(runfolder_name) %> "
+        do:
+          - no_processing_notifier
+
+  no_processing_notifier:
+    action: core.sendmail
+    input:
+      to: <% ctx(mail_bioinfo) %>
+      from: stanley@clinicalgenomics-as.se
+      subject: "[DUCTUS][WP][ERROR] - Processing stopped for experiment on run, <% ctx(runfolder_name) %>"
+      body: The following run contains one or several experiments that can't be processed, <% ctx(runfolder_name) %>
+    next:
+      - when: <% succeeded() %> or <% failed() %>
+        do:
+          - mark_as_done
   
   detect_old_samplesheet_format:
     action: core.local
@@ -422,6 +449,9 @@ tasks:
         do:
           - bioinfo_error_notifier
           - mark_as_failed
+      - when: <% succeeded() %>
+        do: 
+          - mark_as_done
 
   bioinfo_error_notifier:
     action: core.sendmail
@@ -457,6 +487,13 @@ tasks:
       - when: <% succeeded() %>
         do:
           - fail
+
+  mark_as_done:
+    action: core.http
+    input:
+      url: http://<% ctx(runfolder_host) %>:<% ctx(runfolder_host_port) %>/api/<% ctx(runfolder_api_version) %>/runfolders/path<% ctx(runfolder) %>
+      body: '{"state": "done"}'
+      method: "POST"
 
   mark_as_failed:
     action: core.http


### PR DESCRIPTION
This PR includes 3 new tasks:
-  **filter_experiment_samplesheet**, will detect if the bioinformatic
  sample sheet contains experiment names that should not be processed.
-  **no_processing_notifier**, will send an e-mail to bioinformaticians if a
  run contains an experiment name that should not be processed. After
this task the run will be marked as done.
-  **mark_as_done**, will update the state of a rum to done.