### PR TITLE
feat: Error notifier ex

### DIFF
--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -462,8 +462,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][ERROR] - Pre-processing, <% ctx(runfolder_name) %>"
-      body: Something went wrong during the population of the processing api with <% ctx(runfolder_name) %>, please investigate!!!\n 
-      Failure message -- <% ctx(failed_step) %>, <% ctx(stderr) %> Workflow execution id - <% ctx().st2.action_execution_id %>
+      body: Something went wrong during the population of the processing api with <% ctx(runfolder_name) %>, please investigate!!!\n Failure message -- <% ctx(failed_step) %>, <% ctx(stderr) %> Workflow execution id - <% ctx().st2.action_execution_id %>
     next:
       - do:
           - fail

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -179,7 +179,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][INFO] - Sample sheet , <% ctx(runfolder_name) %>"
-      body: The following content was found in sample sheet <% ctx(samplesheet_file) %>\n <% ctx(samplesheet_content) %>
+      body: The following content was found in sample sheet <% ctx(samplesheet_file) %>\n <% ctx(samplesheet_content) %> \n Workflow execution id - <% ctx().st2.action_execution_id %> \n Host - Hospital
     next:
       - when: <% succeeded() %> or <% failed() %>
         do:
@@ -222,7 +222,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][INFO] - Processing stopped for experiment on run, <% ctx(runfolder_name) %>"
-      body: The following run contains one or several experiments that can't be processed, <% ctx(runfolder_name) %>
+      body: The following run contains one or several experiments that can't be processed, <% ctx(runfolder_name) %> \n Workflow execution id - <% ctx().st2.action_execution_id %> \n Host - Hospital
     next:
       - when: <% succeeded() %> or <% failed() %>
         do:
@@ -473,7 +473,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][ERROR] -  <% ctx(runfolder_name) %>"
-      body: Couldn't find CompletedJobInfo.xml for <% ctx(runfolder_name) %>
+      body: Couldn't find CompletedJobInfo.xml for <% ctx(runfolder_name) %> \n Workflow execution id - <% ctx().st2.action_execution_id %> \n Host - Hospital
     next:
       - when: <% succeeded() %>
         do:
@@ -485,7 +485,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>"
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][ERROR] - Incorrect machine typ <% ctx(runfolder_name) %>"
-      body: Couldn't parse the machine type from the runfolder name, <% ctx(runfolder_name) %>. New machine or have the folder name been changed?
+      body: Couldn't parse the machine type from the runfolder name, <% ctx(runfolder_name) %>. New machine or have the folder name been changed? \n Workflow execution id - <% ctx().st2.action_execution_id %> \n Host - Hospital
     next:
       - when: <% succeeded() %>
         do:

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -462,7 +462,8 @@ tasks:
       to: <% ctx(mail_bioinfo) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][ERROR] - Pre-processing, <% ctx(runfolder_name) %>"
-      body: Something went wrong during the population of the processing api with <% ctx(runfolder_name) %>, please investigate!!!\n Failure message -- <% ctx(failed_step) %>, <% ctx(stderr) %>
+      body: Something went wrong during the population of the processing api with <% ctx(runfolder_name) %>, please investigate!!!\n 
+      Failure message -- <% ctx(failed_step) %>, <% ctx(stderr) %> Workflow execution id - <% ctx().st2.action_execution_id %>
     next:
       - do:
           - fail

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -462,7 +462,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][ERROR] - Pre-processing, <% ctx(runfolder_name) %>"
-      body: Something went wrong during the population of the processing api with <% ctx(runfolder_name) %>, please investigate!!!\n Failure message -- <% ctx(failed_step) %>, <% ctx(stderr) %> Workflow execution id - <% ctx().st2.action_execution_id %>
+      body: Something went wrong during the population of the processing api with <% ctx(runfolder_name) %>, please investigate!!!\n Failure message -- <% ctx(failed_step) %>, <% ctx(stderr) %> \n Workflow execution id - <% ctx().st2.action_execution_id %> \n Host - Hospital
     next:
       - do:
           - fail


### PR DESCRIPTION
All e-mails sent from ductus.populate_processing_api_with_sequencerun will now include an execution id to the corresponding workflow (not action) and the host (in this case Hospital) for the stackstorm instance running the workflow.

Test: Only manually tested on local computer. No unit tests or integrations tests available.