### PR TITLE
chore(interop_files.yaml): Increase timeout copy

### DIFF
--- a/actions/workflows/archive/interop_files.yaml
+++ b/actions/workflows/archive/interop_files.yaml
@@ -105,7 +105,7 @@ tasks:
     action: core.local
     input:
       cmd: cp -r <% ctx(runfolder_path) %>/<% item() %> <% ctx(archive_folder) %>/
-      timeout: 300
+      timeout: 600
     retry:
       count: 5
       delay: 60


### PR DESCRIPTION
Sometimes we get a timeout when copying the InterOp-directory generated by the NovaSeqX in the archive_interop_files-workflow. I have now doubled the timeout limit for action copy_sav_info from 300 sec to 600 sec.