### PR TITLE
feat: Validate number of fastq-files transfered from instrument to storage

### DIFF
--- a/actions/populate_processing_api_with_sequencerun.yaml
+++ b/actions/populate_processing_api_with_sequencerun.yaml
@@ -118,3 +118,8 @@ parameters:
     required: true
     type: integer
     default: "{{ config_context.processing_api_json_update_wait_time_for_fastq_files }}"
+  transfer_to_storage_wait_time_for_fastq_files:
+    required: true
+    type: integer
+    default: "{{ config_context.transfer_to_storage_wait_time_for_fastq_files }}"
+    

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -404,11 +404,34 @@ tasks:
       - when: <% succeeded %>
         publish: samples=<% result().stdout %>
         do:
-          - create_fastq_update_query
+          - check_number_of_fastqs
       - when: <% failed() %>
         publish:
           - stderr: <% result() %>
           - failed_step: "get_samples -- Could not fetch samples for <% ctx(runfolder_name) %>"
+        do:
+          - bioinfo_error_notifier
+          - mark_as_failed
+
+  check_number_of_fastqs:
+    join: 1
+    action: core.local
+    delay: 30
+    input:
+      cmd: python3 -c 'from ductus.tools.utils import get_nr_expected_fastqs; import sys, glob; exit(0) if get_nr_expected_fastqs("<% ctx(samplesheet_file) %>", glob.glob("<% ctx(fastq_files_path) %>/**/*.fastq.gz", recursive=True)) == 1 else exit(1)'
+      timeout: 300
+    retry:
+      when: <% failed() %>
+      count: 10
+      delay: 300
+    next:
+      - when: <% succeeded %>
+        do:
+          - create_fastq_update_query
+      - when: <% failed() %>
+        publish:
+          - stderr: <% result() %>
+          - failed_step: "check_number_of_fastqs -- Could not find the expected number of fastq files for <% ctx(runfolder_name) %>"
         do:
           - bioinfo_error_notifier
           - mark_as_failed

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -50,6 +50,7 @@ vars:
   - stderr: null
   - machine_name: null
   - samplesheet_content: null
+  - samplesheet_file_demux: null
 
 tasks:
   setting_runfolder:
@@ -94,7 +95,9 @@ tasks:
       cmd: ls <% ctx(runfolder) %>/SampleSheet.csv || ls <% ctx(runfolder) %>/*/SampleSheet.csv
     next:
       - when: <% succeeded() %>
-        publish: samplesheet_file=<% result().stdout %>
+        publish: 
+          - samplesheet_file: <% result().stdout %>
+          - samplesheet_file_demux: <% result().stdout %>
         do:
           - check_for_runinfo
       - when: <% failed() %>
@@ -419,7 +422,7 @@ tasks:
     action: core.local
     delay: 30
     input:
-      cmd: python3 -c 'from ductus.tools.utils import get_nr_expected_fastqs; import sys, glob; exit(0) if get_nr_expected_fastqs("<% ctx(samplesheet_file) %>", glob.glob("<% ctx(fastq_files_path) %>/**/*.fastq.gz", recursive=True)) == 1 else exit(1)'
+      cmd: python3 -c 'from ductus.tools.utils import get_nr_expected_fastqs; import sys, glob; exit(0) if get_nr_expected_fastqs("<% ctx(samplesheet_file_demux) %>", glob.glob("<% ctx(fastq_files_path) %>/**/*.fastq.gz", recursive=True)) == 1 else exit(1)'
       timeout: 300
     retry:
       when: <% failed() %>

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -29,6 +29,7 @@ input:
   - sample_update_json_folder_path
   - path_complete_file
   - processing_api_json_update_wait_time_for_fastq_files
+  - transfer_to_storage_wait_time_for_fastq_files
 
 vars:
   - runfolder_host: null
@@ -422,8 +423,8 @@ tasks:
       timeout: 300
     retry:
       when: <% failed() %>
-      count: 10
-      delay: 300
+      count: 36
+      delay: <% ctx(transfer_to_storage_wait_time_for_fastq_files) %>
     next:
       - when: <% succeeded %>
         do:

--- a/config.scheme.yaml
+++ b/config.scheme.yaml
@@ -23,6 +23,12 @@
     type: integer
     default: 300
 
+  transfer_to_storage_wait_time_for_fastq_files:
+    description: time between retries when counting number of transfered fastq-files from instrument to storage 
+    type: integer
+    required: true
+    default: 10
+
   arteria_runfolder_addresses:
     description: list of addresses for arteria-runfolder services
     type: array


### PR DESCRIPTION
In this PR an new task, check_number_of_fastqs, is added to the workflow populate_processing_api_with_sequencerun.yaml. This task is joint with get_nr_expected_fastqs in ductus-core that is using the sample sheet to estimate the number of fastq-files that should be transferred from the instrument to storage for a specific run.

Since transfers of fastq-files can be slow, especially for large NovaseqX runs, a delay and retry was also implemented.