### PR TITLE
chore: dev to master

### DIFF
--- a/actions/populate_processing_api_with_sequencerun.yaml
+++ b/actions/populate_processing_api_with_sequencerun.yaml
@@ -118,3 +118,8 @@ parameters:
     required: true
     type: integer
     default: "{{ config_context.processing_api_json_update_wait_time_for_fastq_files }}"
+  transfer_to_storage_wait_time_for_fastq_files:
+    required: true
+    type: integer
+    default: "{{ config_context.transfer_to_storage_wait_time_for_fastq_files }}"
+    

--- a/actions/workflows/archive/interop_files.yaml
+++ b/actions/workflows/archive/interop_files.yaml
@@ -118,9 +118,11 @@ tasks:
           - stderr: <% result() %>
 
   copy_metrics:
+    with:
+      items: <% ctx(sav_machine_type_fold_and_extra_files).get(ctx(machine_id)).get('path_metrics') %>
     action: core.local
     input:
-      cmd: cp -r <% ctx(runfolder_path) %>/<% ctx(sav_machine_type_fold_and_extra_files).get(ctx(machine_id)).get('path_metrics') %> <% ctx(archive_folder) %>/InterOp/
+      cmd: cp -r <% ctx(runfolder_path) %>/<% item() %> <% ctx(archive_folder) %>/InterOp/
       timeout: 300
     retry:
       count: 30

--- a/actions/workflows/archive/interop_files.yaml
+++ b/actions/workflows/archive/interop_files.yaml
@@ -105,7 +105,7 @@ tasks:
     action: core.local
     input:
       cmd: cp -r <% ctx(runfolder_path) %>/<% item() %> <% ctx(archive_folder) %>/
-      timeout: 300
+      timeout: 600
     retry:
       count: 5
       delay: 60

--- a/actions/workflows/copy_data_to_cluster_for_processing.yaml
+++ b/actions/workflows/copy_data_to_cluster_for_processing.yaml
@@ -108,7 +108,7 @@ tasks:
     next:
       - when: <% failed() %>
         publish:
-          - stderr: <% result() %>
+          - stderr: "The transfer of fastq files from hospital to compute failed."
           - failed_step: "transfer_fastq_file -- couldn't transfer fastq-file(s) to <% ctx(upload_path) %>/fastq/"
         do:
           - bioinfo_error_notifier
@@ -139,7 +139,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][ERROR] - Pre-processing, <% ctx(analysis_name) %>"
-      body: Something went wrong during the pre-processing of <% ctx(analysis_name) %>, please investigate!!!\n Failure message -- <% ctx(failed_step) %>, <% ctx(stderr) %>
+      body: Something went wrong during the pre-processing of <% ctx(analysis_name) %>, please investigate!!!\n Failure message -- <% ctx(failed_step) %>, <% ctx(stderr) %>  Workflow execution id - <% ctx().st2.action_execution_id %>  Host - Hospital
     next:
       - when: <% succeeded() %>
         do:

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -29,6 +29,7 @@ input:
   - sample_update_json_folder_path
   - path_complete_file
   - processing_api_json_update_wait_time_for_fastq_files
+  - transfer_to_storage_wait_time_for_fastq_files
 
 vars:
   - runfolder_host: null
@@ -49,6 +50,7 @@ vars:
   - stderr: null
   - machine_name: null
   - samplesheet_content: null
+  - samplesheet_file_demux: null
 
 tasks:
   setting_runfolder:
@@ -93,7 +95,9 @@ tasks:
       cmd: ls <% ctx(runfolder) %>/SampleSheet.csv || ls <% ctx(runfolder) %>/*/SampleSheet.csv
     next:
       - when: <% succeeded() %>
-        publish: samplesheet_file=<% result().stdout %>
+        publish: 
+          - samplesheet_file: <% result().stdout %>
+          - samplesheet_file_demux: <% result().stdout %>
         do:
           - check_for_runinfo
       - when: <% failed() %>
@@ -404,11 +408,34 @@ tasks:
       - when: <% succeeded %>
         publish: samples=<% result().stdout %>
         do:
-          - create_fastq_update_query
+          - check_number_of_fastqs
       - when: <% failed() %>
         publish:
           - stderr: <% result() %>
           - failed_step: "get_samples -- Could not fetch samples for <% ctx(runfolder_name) %>"
+        do:
+          - bioinfo_error_notifier
+          - mark_as_failed
+
+  check_number_of_fastqs:
+    join: 1
+    action: core.local
+    delay: 30
+    input:
+      cmd: python3 -c 'from ductus.tools.utils import get_nr_expected_fastqs; import sys, glob; exit(0) if get_nr_expected_fastqs("<% ctx(samplesheet_file_demux) %>", glob.glob("<% ctx(fastq_files_path) %>/**/*.fastq.gz", recursive=True)) == 1 else exit(1)'
+      timeout: 300
+    retry:
+      when: <% failed() %>
+      count: 36
+      delay: <% ctx(transfer_to_storage_wait_time_for_fastq_files) %>
+    next:
+      - when: <% succeeded %>
+        do:
+          - create_fastq_update_query
+      - when: <% failed() %>
+        publish:
+          - stderr: <% result() %>
+          - failed_step: "check_number_of_fastqs -- Could not find the expected number of fastq files for <% ctx(runfolder_name) %>"
         do:
           - bioinfo_error_notifier
           - mark_as_failed

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -183,23 +183,7 @@ tasks:
     next:
       - when: <% succeeded() %> or <% failed() %>
         do:
-          - archive_sav_files
-  
-  archive_sav_files:
-    action: ductus.archive_interop_files
-    input:
-      runinfo_file_path: <% ctx(runinfo_file) %>
-    next:
-      - when: <% succeeded() %>
-        do:
           - filter_experiment_samplesheet
-      - when: <% failed() %>
-        publish:
-          - stderr: <% result() %>
-          - failed_step: "archive_sav_files -- Could not archive SAV files for <% ctx(runfolder_name) %>"
-        do:
-          - bioinfo_error_notifier
-          - mark_as_failed
 
   filter_experiment_samplesheet:
     action: core.local
@@ -353,7 +337,7 @@ tasks:
           publish:
             - fastq_files_path: "<% ctx(demultiplexing_output_folder) %>/<% ctx(runfolder_name) %>"
           do:
-            get_samples
+            archive_sav_files
         - when: <% failed() %>
           publish:
             - stderr: "Demultplexing failed"
@@ -392,9 +376,25 @@ tasks:
       delay: <% ctx(demultiplexing_delay) %>
     next:
       - when: <% succeeded() %>
-        do: get_samples
+        do: archive_sav_files
       - when: <% failed() %>
         do: completed_job_file_missing
+          
+  archive_sav_files:
+    action: ductus.archive_interop_files
+    input:
+      runinfo_file_path: <% ctx(runinfo_file) %>
+    next:
+      - when: <% succeeded() %>
+        do:
+          - get_samples
+      - when: <% failed() %>
+        publish:
+          - stderr: <% result() %>
+          - failed_step: "archive_sav_files -- Could not archive SAV files for <% ctx(runfolder_name) %>"
+        do:
+          - bioinfo_error_notifier
+          - mark_as_failed
         
   get_samples:
     action: core.local

--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -179,7 +179,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][INFO] - Sample sheet , <% ctx(runfolder_name) %>"
-      body: The following content was found in sample sheet <% ctx(samplesheet_file) %>\n <% ctx(samplesheet_content) %>
+      body: The following content was found in sample sheet <% ctx(samplesheet_file) %>\n <% ctx(samplesheet_content) %> \n Workflow execution id - <% ctx().st2.action_execution_id %> \n Host - Hospital
     next:
       - when: <% succeeded() %> or <% failed() %>
         do:
@@ -222,7 +222,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][INFO] - Processing stopped for experiment on run, <% ctx(runfolder_name) %>"
-      body: The following run contains one or several experiments that can't be processed, <% ctx(runfolder_name) %>
+      body: The following run contains one or several experiments that can't be processed, <% ctx(runfolder_name) %> \n Workflow execution id - <% ctx().st2.action_execution_id %> \n Host - Hospital
     next:
       - when: <% succeeded() %> or <% failed() %>
         do:
@@ -462,7 +462,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][ERROR] - Pre-processing, <% ctx(runfolder_name) %>"
-      body: Something went wrong during the population of the processing api with <% ctx(runfolder_name) %>, please investigate!!!\n Failure message -- <% ctx(failed_step) %>, <% ctx(stderr) %>
+      body: Something went wrong during the population of the processing api with <% ctx(runfolder_name) %>, please investigate!!!\n Failure message -- <% ctx(failed_step) %>, <% ctx(stderr) %> \n Workflow execution id - <% ctx().st2.action_execution_id %> \n Host - Hospital
     next:
       - do:
           - fail
@@ -473,7 +473,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][ERROR] -  <% ctx(runfolder_name) %>"
-      body: Couldn't find CompletedJobInfo.xml for <% ctx(runfolder_name) %>
+      body: Couldn't find CompletedJobInfo.xml for <% ctx(runfolder_name) %> \n Workflow execution id - <% ctx().st2.action_execution_id %> \n Host - Hospital
     next:
       - when: <% succeeded() %>
         do:
@@ -485,7 +485,7 @@ tasks:
       to: <% ctx(mail_bioinfo) %>"
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][WP][ERROR] - Incorrect machine typ <% ctx(runfolder_name) %>"
-      body: Couldn't parse the machine type from the runfolder name, <% ctx(runfolder_name) %>. New machine or have the folder name been changed?
+      body: Couldn't parse the machine type from the runfolder name, <% ctx(runfolder_name) %>. New machine or have the folder name been changed? \n Workflow execution id - <% ctx().st2.action_execution_id %> \n Host - Hospital
     next:
       - when: <% succeeded() %>
         do:

--- a/actions/workflows/retrieve_result_wp.yaml
+++ b/actions/workflows/retrieve_result_wp.yaml
@@ -175,9 +175,8 @@ tasks:
         do:
           - create_qc_year_folder
       - when: <% failed() %>
-      - when: <% failed() %>
         publish:
-          - stderr: <% result() %>
+          - stderr: "The transfer of fastq files from compute to hospital failed."
           - failed_step: 'transfer_result  -- Could not fetch result from <% ctx(transfer_from_host) %>\:<% ctx(runfolder) %>, <% result() %>'
         do:
           - bioinfo_error_notifier
@@ -246,7 +245,7 @@ tasks:
       to: <% ctx(mail_settings).get('bioinfo') %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][<% ctx(workpackage) %>][<% ctx(method) %>][ERROR] - Retrieve, <% ctx(experiment_name) %>"
-      body: Something went wrong during the retrieval of <% ctx(experiment_name) %>, please investigate!!!\n Failure message -- <% failed_step  %>, <% ctx(stderr) %>
+      body: Something went wrong during the retrieval of <% ctx(experiment_name) %>, please investigate!!!\n Failure message -- <% failed_step  %>, <% ctx(stderr) %> \n Workflow execution id - <% ctx().st2.action_execution_id %> \n Host - Hospital
     next:
       - when: <% succeeded() %>
         do:
@@ -285,7 +284,7 @@ tasks:
       to: <% ctx(mail_settings).get('lab').get(ctx(workpackage)) %>
       from: stanley@clinicalgenomics-as.se
       subject: "[DUCTUS][<% ctx(workpackage) %>][<% ctx(method) %>][SUCCESS] - Analysis available, <% ctx(experiment_name) %>"
-      body: The result from analysis of <% ctx(experiment_name) %> can now be accessed.
+      body: The result from analysis of <% ctx(experiment_name) %> can now be accessed. \n Workflow execution id - <% ctx().st2.action_execution_id %> \n Host - Hospital
 
 output:
   - stderr: "<% ctx(stderr) %>"

--- a/config.scheme.yaml
+++ b/config.scheme.yaml
@@ -23,6 +23,12 @@
     type: integer
     default: 300
 
+  transfer_to_storage_wait_time_for_fastq_files:
+    description: time between retries when counting number of transfered fastq-files from instrument to storage 
+    type: integer
+    required: true
+    default: 10
+
   arteria_runfolder_addresses:
     description: list of addresses for arteria-runfolder services
     type: array


### PR DESCRIPTION
-  Do not print the rsync-log to stderr in copy_data_to_cluster_for_processing.yaml and retrieve_result_wp.yaml since the core.sendmail action can't handle the size/format of the log. Instead print a general and short error message.
-  In this PR an new task, check_number_of_fastqs, is added to the workflow populate_processing_api_with_sequencerun.yaml. This task is joint with get_nr_expected_fastqs in ductus-core that is using the sample sheet to estimate the number of fastq-files that should be transferred from the instrument to storage for a specific run. Since transfers of fastq-files can be slow, especially for large NovaseqX runs, a delay and retry was also implemented.