### PR TITLE
fix(transfer fastqs): Increased retries

### DIFF
--- a/actions/workflows/populate_processing_api_with_sequencerun.yaml
+++ b/actions/workflows/populate_processing_api_with_sequencerun.yaml
@@ -426,7 +426,7 @@ tasks:
       timeout: 300
     retry:
       when: <% failed() %>
-      count: 36
+      count: 60
       delay: <% ctx(transfer_to_storage_wait_time_for_fastq_files) %>
     next:
       - when: <% succeeded %>


### PR DESCRIPTION
Increased number of retries (from 36 to 60) when checking if all fastq-files has been transferred from instrument to storage. 