### PR TITLE
fix(run_analysis): Write script stdout to dev/null

### DIFF
--- a/actions/workflows/run_analysis.yaml
+++ b/actions/workflows/run_analysis.yaml
@@ -100,7 +100,7 @@ tasks:
       private_key: <% ctx(process_key) %>
       hosts: <% ctx(process_host) %>
       cwd: <% ctx(analysis_folder_path) %>
-      cmd: bash <% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('run_script') %> --inbox-path <% ctx(runfolder) %> <% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('parameters') %>
+      cmd: bash <% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('run_script') %> --inbox-path <% ctx(runfolder) %> <% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('parameters') %> > /dev/null 2>&1
       timeout: <% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('timeout', 259200) %>
     next:
       - when: <% succeeded() and ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('outbox_files_and_folders', null) %>


### PR DESCRIPTION
- When a pipeline runscript is started with bash with core.remote in stackstorm the script log (in this case all snakemake) output will be returned to the task. However, MongoDB can only store up to 16Mb large items and when a pipeline output more than that the task will crash even if the pipeline is succeeded.
- With this fix the script stdout and stderr, i.e. the pipeline output will be written to dev/null instead. Unfortunately this will not only hide the output from the snakemake command. If something else in the runscript is wrong it will be really hard to troubleshoot.
-  A better fix is probably to write the snakemake command in the runscript to dev/null since this output will be saved in the snakemake-log.