### PR TITLE
feat: add upload_completed and download_ready sensors

### DIFF
--- a/sensors/download_ready_sensor.py
+++ b/sensors/download_ready_sensor.py
@@ -1,0 +1,60 @@
+from st2reactor.sensor.base import PollingSensor
+from processing_api_client import ProcessingApiClient
+from datetime import datetime, timezone
+
+
+class DownloadReadySensor(PollingSensor):
+
+    def __init__(self, sensor_service, config=None, poll_interval=None, trigger='ductus.data_ready_for_download'):
+        super(DownloadReadySensor, self).__init__(sensor_service=sensor_service,
+                                                  config=config,
+                                                  poll_interval=poll_interval)
+        self._logger = self._sensor_service.get_logger(__name__)
+        self._infolog("__init__")
+        self._client = None
+        self._trigger = trigger
+
+    def setup(self):
+        self._infolog("setup")
+        base_url = self._config["processing_api_service_url"].rstrip("/")
+        path = self._config["processing_api_ready_for_download_next_url"].lstrip("/")
+        client_url = "{}/{}".format(base_url, path)
+        api_key = self._config["processing_api_access_key"]
+        self._client = ProcessingApiClient(client_url, api_key, self._logger)
+        self._infolog("Created client: {0}".format(self._client))
+        self._infolog("setup finished")
+
+    def poll(self):
+        self._infolog("poll")
+        self._infolog("Checking api for new entries")
+        result = self._client.next_ready()
+        self._infolog("Result from client: {0}".format(result))
+        if result:
+            self._handle_result(result)
+
+    def cleanup(self):
+        self._infolog("cleanup")
+
+    def add_trigger(self, trigger):
+        self._infolog("add_trigger")
+
+    def update_trigger(self, trigger):
+        self._infolog("update_trigger")
+
+    def remove_trigger(self, trigger):
+        self._infolog("remove_trigger")
+
+    def _handle_result(self, result):
+        self._infolog("_handle_result")
+        trigger = self._trigger
+
+        analysis_data = result['response']
+        payload = {
+            **analysis_data,
+            'event': 'data_ready_for_download',
+            'timestamp': datetime.now(timezone.utc).isoformat(),
+        }
+        self._sensor_service.dispatch(trigger=trigger, payload=payload, trace_tag=analysis_data['analysis_name'])
+
+    def _infolog(self, msg):
+        self._logger.info("[ductus-packs." + self.__class__.__name__ + "] " + msg)

--- a/sensors/download_ready_sensor.yaml
+++ b/sensors/download_ready_sensor.yaml
@@ -1,0 +1,18 @@
+---
+  class_name: "DownloadReadySensor"
+  entry_point: "download_ready_sensor.py"
+  description: "Sensor which queries processing api for analyses ready for download"
+  poll_interval: 15 # Every 15 s
+  trigger_types:
+    -
+      name: "download_ready"
+      description: "Trigger which indicates that an analysis is ready for download"
+      payload_schema:
+        type: "object"
+        properties:
+         analysis_name:
+           type: "string"
+         event:
+           type: "string"
+         timestamp:
+           type: "string"

--- a/sensors/upload_completed_sensor.py
+++ b/sensors/upload_completed_sensor.py
@@ -1,0 +1,60 @@
+from st2reactor.sensor.base import PollingSensor
+from processing_api_client import ProcessingApiClient
+from datetime import datetime, timezone
+
+
+class UploadCompletedSensor(PollingSensor):
+
+    def __init__(self, sensor_service, config=None, poll_interval=None, trigger='ductus.upload_completed'):
+        super(UploadCompletedSensor, self).__init__(sensor_service=sensor_service,
+                                                    config=config,
+                                                    poll_interval=poll_interval)
+        self._logger = self._sensor_service.get_logger(__name__)
+        self._infolog("__init__")
+        self._client = None
+        self._trigger = trigger
+
+    def setup(self):
+        self._infolog("setup")
+        base_url = self._config["processing_api_service_url"].rstrip("/")
+        path = self._config["processing_api_upload_completed_next_url"].lstrip("/")
+        client_url = "{}/{}".format(base_url, path)
+        api_key = self._config["processing_api_access_key"]
+        self._client = ProcessingApiClient(client_url, api_key, self._logger)
+        self._infolog("Created client: {0}".format(self._client))
+        self._infolog("setup finished")
+
+    def poll(self):
+        self._infolog("poll")
+        self._infolog("Checking api for new entries")
+        result = self._client.next_ready()
+        self._infolog("Result from client: {0}".format(result))
+        if result:
+            self._handle_result(result)
+
+    def cleanup(self):
+        self._infolog("cleanup")
+
+    def add_trigger(self, trigger):
+        self._infolog("add_trigger")
+
+    def update_trigger(self, trigger):
+        self._infolog("update_trigger")
+
+    def remove_trigger(self, trigger):
+        self._infolog("remove_trigger")
+
+    def _handle_result(self, result):
+        self._infolog("_handle_result")
+        trigger = self._trigger
+
+        analysis_data = result['response']
+        payload = {
+            **analysis_data,
+            'event': 'upload_completed',
+            'timestamp': datetime.now(timezone.utc).isoformat(),
+        }
+        self._sensor_service.dispatch(trigger=trigger, payload=payload, trace_tag=analysis_data['analysis_name'])
+
+    def _infolog(self, msg):
+        self._logger.info("[ductus-packs." + self.__class__.__name__ + "] " + msg)

--- a/sensors/upload_completed_sensor.yaml
+++ b/sensors/upload_completed_sensor.yaml
@@ -1,0 +1,18 @@
+---
+  class_name: "UploadCompletedSensor"
+  entry_point: "upload_completed_sensor.py"
+  description: "Sensor which queries processing api for analyses where upload is completed"
+  poll_interval: 15 # Every 15 s
+  trigger_types:
+    -
+      name: "upload_completed"
+      description: "Trigger which indicates that an analysis upload has completed"
+      payload_schema:
+        type: "object"
+        properties:
+         analysis_name:
+           type: "string"
+         event:
+           type: "string"
+         timestamp:
+           type: "string"

--- a/tests/test_download_ready_sensor.py
+++ b/tests/test_download_ready_sensor.py
@@ -1,0 +1,58 @@
+from unittest import mock
+from st2tests.base import BaseSensorTestCase
+from sensors.download_ready_sensor import DownloadReadySensor
+
+class DownloadReadySensorTestCase(BaseSensorTestCase):
+    sensor_cls = DownloadReadySensor
+
+    CONFIG = {
+        'processing_api_service_url': 'http://processing_api:8080/',
+        'processing_api_ready_for_download_next_url': 'api/v1/analysis/ready-for-download/next/',
+        'processing_api_access_key': 'asdajl3j5ads'
+    }
+
+    def _setup_and_poll(self, mock_get, status_code, response_text):
+        mock_response = mock.MagicMock()
+        mock_response.status_code = status_code
+        mock_response.text = response_text
+        mock_get.return_value = mock_response
+
+        sensor = self.get_sensor_instance(config=self.CONFIG)
+        sensor.setup()
+        sensor.poll()
+        return self.get_dispatched_triggers()
+
+    @mock.patch('sensors.processing_api_client.requests.get')
+    def test_fetch_download_ready_event(self, mock_get):
+        """Test that a trigger is dispatched when an analysis is ready for download"""
+        contexts = self._setup_and_poll(
+            mock_get, 200,
+            '{"analysis_name": "240101_A00123_0001_ABCDEFGHIJ"}'
+        )
+
+        self.assertGreater(len(contexts), 0)
+        self.assertEqual(contexts[0]['trigger'], 'ductus.data_ready_for_download')
+        self.assertEqual(contexts[0]['payload']['analysis_name'], '240101_A00123_0001_ABCDEFGHIJ')
+        self.assertEqual(contexts[0]['payload']['event'], 'ready_for_download')
+        self.assertIn('timestamp', contexts[0]['payload'])
+
+    @mock.patch('sensors.processing_api_client.requests.get')
+    def test_fetch_download_ready_event_second_analysis(self, mock_get):
+        """Test that a trigger is dispatched for a different analysis"""
+        contexts = self._setup_and_poll(
+            mock_get, 200,
+            '{"analysis_name": "240202_B00456_0002_BCDEFGHIJK"}'
+        )
+
+        self.assertGreater(len(contexts), 0)
+        self.assertEqual(contexts[0]['trigger'], 'ductus.data_ready_for_download')
+        self.assertEqual(contexts[0]['payload']['analysis_name'], '240202_B00456_0002_BCDEFGHIJK')
+        self.assertEqual(contexts[0]['payload']['event'], 'ready_for_download')
+        self.assertIn('timestamp', contexts[0]['payload'])
+
+    @mock.patch('sensors.processing_api_client.requests.get')
+    def test_fetch_download_ready_event_no_data_exist(self, mock_get):
+        """Test that no trigger is dispatched when no data is available"""
+        contexts = self._setup_and_poll(mock_get, 204, '{}')
+
+        self.assertEqual(len(contexts), 0)

--- a/tests/test_upload_completed_sensor.py
+++ b/tests/test_upload_completed_sensor.py
@@ -1,0 +1,58 @@
+from unittest import mock
+from st2tests.base import BaseSensorTestCase
+from sensors.upload_completed_sensor import UploadCompletedSensor
+
+class UploadCompletedSensorTestCase(BaseSensorTestCase):
+    sensor_cls = UploadCompletedSensor
+
+    CONFIG = {
+        'processing_api_service_url': 'http://processing_api:8080/',
+        'processing_api_upload_completed_next_url': 'api/v1/analysis/upload-completed/next/',
+        'processing_api_access_key': 'asdajl3j5ads'
+    }
+
+    def _setup_and_poll(self, mock_get, status_code, response_text):
+        mock_response = mock.MagicMock()
+        mock_response.status_code = status_code
+        mock_response.text = response_text
+        mock_get.return_value = mock_response
+
+        sensor = self.get_sensor_instance(config=self.CONFIG)
+        sensor.setup()
+        sensor.poll()
+        return self.get_dispatched_triggers()
+
+    @mock.patch('sensors.processing_api_client.requests.get')
+    def test_fetch_upload_completed_event(self, mock_get):
+        """Test that a trigger is dispatched when an upload has completed"""
+        contexts = self._setup_and_poll(
+            mock_get, 200,
+            '{"analysis_name": "240101_A00123_0001_ABCDEFGHIJ"}'
+        )
+
+        self.assertGreater(len(contexts), 0)
+        self.assertEqual(contexts[0]['trigger'], 'ductus.upload_completed')
+        self.assertEqual(contexts[0]['payload']['analysis_name'], '240101_A00123_0001_ABCDEFGHIJ')
+        self.assertEqual(contexts[0]['payload']['event'], 'upload_completed')
+        self.assertIn('timestamp', contexts[0]['payload'])
+
+    @mock.patch('sensors.processing_api_client.requests.get')
+    def test_fetch_upload_completed_event_second_analysis(self, mock_get):
+        """Test that a trigger is dispatched for a different analysis"""
+        contexts = self._setup_and_poll(
+            mock_get, 200,
+            '{"analysis_name": "240202_B00456_0002_BCDEFGHIJK"}'
+        )
+
+        self.assertGreater(len(contexts), 0)
+        self.assertEqual(contexts[0]['trigger'], 'ductus.upload_completed')
+        self.assertEqual(contexts[0]['payload']['analysis_name'], '240202_B00456_0002_BCDEFGHIJK')
+        self.assertEqual(contexts[0]['payload']['event'], 'upload_completed')
+        self.assertIn('timestamp', contexts[0]['payload'])
+
+    @mock.patch('sensors.processing_api_client.requests.get')
+    def test_fetch_upload_completed_event_no_data_exist(self, mock_get):
+        """Test that no trigger is dispatched when no data is available"""
+        contexts = self._setup_and_poll(mock_get, 204, '{}')
+
+        self.assertEqual(len(contexts), 0)


### PR DESCRIPTION
Add two new polling sensors targeting the upload-completed and ready-for-download processing API endpoints, each with corresponding tests.