### PR TITLE
fix: Miarka service rewrite link

### DIFF
--- a/actions/run_analysis_miarka_action.yaml
+++ b/actions/run_analysis_miarka_action.yaml
@@ -25,7 +25,7 @@ parameters:
   process_host_url:
     required: true
     type: string
-    default: "{{ config_context.miarka_processing_service_url }}"
+    default: "{{ config_context.process_host_url }}"
   job_status_url:
     required: true
     type: string
@@ -46,7 +46,7 @@ parameters:
   process_settings:
     required: true 
     type: object
-    default: "{{ config_context.process_settings }}"
+    default: "{{ config_context.process_settings_miarka }}"
   mail_bioinfo:
     required: true
     type: string

--- a/actions/run_analysis_miarka_action.yaml
+++ b/actions/run_analysis_miarka_action.yaml
@@ -26,6 +26,10 @@ parameters:
     required: true
     type: string
     default: "{{ config_context.miarka_processing_service_url }}"
+  job_status_url:
+    required: true
+    type: string
+    default: "{{ config_context.job_status_url }}"
   process_host_gateway_port:
     required: true
     type: string

--- a/actions/workflows/run_analysis_miarka.yaml
+++ b/actions/workflows/run_analysis_miarka.yaml
@@ -51,7 +51,7 @@ tasks:
         -H 'apikey: ***********'
     next:
       - when: <% succeeded() %>
-        publish: create_folder_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.json_parse().link.split("/")[-1] %>
+        publish: create_folder_status_url=<% concat("http://",ctx(process_host_url),":",ctx(process_host_gateway_port),ctx(job_status_url),result().stdout.link.split("/")[-1]) %>
         do:
           - poll_create_folder_status
           - bioinfo_analysis_started
@@ -87,7 +87,7 @@ tasks:
         "parameters": "<% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('parameters') %>" }' http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %>/api/1.0/jobs/start_analysis/
     next:
       - when: <% succeeded() %>
-        publish: analysis_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.json_parse().link.split("/")[-1] %>
+        publish: analysis_status_url=<% concat("http://",ctx(process_host_url),":",ctx(process_host_gateway_port),ctx(job_status_url),result().stdout.link.split("/")[-1]) %>
         do:
           - poll_analysis_status
       - when: <% failed() %>
@@ -136,7 +136,7 @@ tasks:
         -H 'apikey: ***********'
     next:
       - when: <% succeeded() %>
-        publish: create_outbox_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.json_parse().link.split("/")[-1] %>
+        publish: create_outbox_status_url=<% concat("http://",ctx(process_host_url),":",ctx(process_host_gateway_port),ctx(job_status_url),result().stdout.link.split("/")[-1]) %>
         do:
           - poll_create_outbox_status
       - when: <% failed() %>
@@ -169,7 +169,7 @@ tasks:
         "may_exist_filter": <% json_dump(ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('outbox_files_and_folders_that_may_exist', [])) %> }' http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %>/api/1.0/jobs/sync_directory/
     next:
       - when: <% succeeded() %>
-        publish: sync_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.json_parse().link.split("/")[-1] %>
+        publish: sync_status_url=<% concat("http://",ctx(process_host_url),":",ctx(process_host_gateway_port),ctx(job_status_url),result().stdout.link.split("/")[-1]) %>
         do:
           - poll_sync_status
       - when: <% failed() %>

--- a/actions/workflows/run_analysis_miarka.yaml
+++ b/actions/workflows/run_analysis_miarka.yaml
@@ -18,6 +18,7 @@ vars:
   - create_folder_status_url: null
   - create_outbox_status_url: null
   - analysis_folder_path: null
+  - job_status_url: null
   - analysis_status_url: null
   - sync_status_url: null
   - outbox_folder: null
@@ -50,7 +51,7 @@ tasks:
         -H 'apikey: ***********'
     next:
       - when: <% succeeded() %>
-        publish: create_folder_status_url=<% result().stdout.link %>
+        publish: create_folder_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.link.split("/")[-1] %>
         do:
           - poll_create_folder_status
           - bioinfo_analysis_started
@@ -86,7 +87,7 @@ tasks:
         "parameters": "<% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('parameters') %>" }' http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %>/api/1.0/jobs/start_analysis/
     next:
       - when: <% succeeded() %>
-        publish: analysis_status_url=<% result().stdout.link %>
+        publish: analysis_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.link.split("/")[-1] %>
         do:
           - poll_analysis_status
       - when: <% failed() %>
@@ -135,7 +136,7 @@ tasks:
         -H 'apikey: ***********'
     next:
       - when: <% succeeded() %>
-        publish: create_outbox_status_url=<% result().stdout.link %>
+        publish: create_outbox_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.link.split("/")[-1] %>
         do:
           - poll_create_outbox_status
       - when: <% failed() %>
@@ -168,7 +169,7 @@ tasks:
         "may_exist_filter": <% json_dump(ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('outbox_files_and_folders_that_may_exist', [])) %> }' http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %>/api/1.0/jobs/sync_directory/
     next:
       - when: <% succeeded() %>
-        publish: sync_status_url=<% result().stdout.link %>
+        publish: sync_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.link.split("/")[-1] %>
         do:
           - poll_sync_status
       - when: <% failed() %>

--- a/actions/workflows/run_analysis_miarka.yaml
+++ b/actions/workflows/run_analysis_miarka.yaml
@@ -7,6 +7,7 @@ input:
     - process_host_proj_path
     - process_host_url
     - process_host_gateway_port
+    - job_status_url
     - experiment_name
     - workpackage
     - analysis
@@ -18,7 +19,6 @@ vars:
   - create_folder_status_url: null
   - create_outbox_status_url: null
   - analysis_folder_path: null
-  - job_status_url: null
   - analysis_status_url: null
   - sync_status_url: null
   - outbox_folder: null
@@ -51,7 +51,7 @@ tasks:
         -H 'apikey: ***********'
     next:
       - when: <% succeeded() %>
-        publish: create_folder_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.link.split("/")[-1] %>
+        publish: create_folder_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.json_parse().link.split("/")[-1] %>
         do:
           - poll_create_folder_status
           - bioinfo_analysis_started
@@ -87,7 +87,7 @@ tasks:
         "parameters": "<% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('parameters') %>" }' http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %>/api/1.0/jobs/start_analysis/
     next:
       - when: <% succeeded() %>
-        publish: analysis_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.link.split("/")[-1] %>
+        publish: analysis_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.json_parse().link.split("/")[-1] %>
         do:
           - poll_analysis_status
       - when: <% failed() %>
@@ -136,7 +136,7 @@ tasks:
         -H 'apikey: ***********'
     next:
       - when: <% succeeded() %>
-        publish: create_outbox_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.link.split("/")[-1] %>
+        publish: create_outbox_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.json_parse().link.split("/")[-1] %>
         do:
           - poll_create_outbox_status
       - when: <% failed() %>
@@ -169,7 +169,7 @@ tasks:
         "may_exist_filter": <% json_dump(ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('outbox_files_and_folders_that_may_exist', [])) %> }' http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %>/api/1.0/jobs/sync_directory/
     next:
       - when: <% succeeded() %>
-        publish: sync_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.link.split("/")[-1] %>
+        publish: sync_status_url=<% "http://" + ctx(process_host_url) + ":" + ctx(process_host_gateway_port) + ctx(job_status_url) + result().stdout.json_parse().link.split("/")[-1] %>
         do:
           - poll_sync_status
       - when: <% failed() %>

--- a/actions/workflows/run_analysis_miarka.yaml
+++ b/actions/workflows/run_analysis_miarka.yaml
@@ -47,7 +47,7 @@ tasks:
     input:
       cmd: >
         curl -s -X POST --data '{"path": "<% ctx(analysis_folder_path) %>" }'
-        -k http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %>/api/1.0/jobs/create_directory/
+        -k http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %><% ctx(job_status_url) %>create_directory/
         -H 'apikey: ***********'
     next:
       - when: <% succeeded() %>
@@ -84,7 +84,7 @@ tasks:
         "analysis_path": "<% ctx(analysis_folder_path) %>",
         "runscript": "<% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('run_script') %>",
         "inbox_path": "<% ctx(runfolder) %>",
-        "parameters": "<% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('parameters') %>" }' http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %>/api/1.0/jobs/start_analysis/
+        "parameters": "<% ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('parameters') %>" }' http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %><% ctx(job_status_url) %>start_analysis/
     next:
       - when: <% succeeded() %>
         publish: analysis_status_url=<% concat("http://",ctx(process_host_url),":",ctx(process_host_gateway_port),ctx(job_status_url),result().stdout.link.split("/")[-1]) %>
@@ -132,7 +132,7 @@ tasks:
     input:
       cmd: >
         curl -s -X POST --data '{"path": "<% ctx(outbox_folder) %>" }'
-        -k http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %>/api/1.0/jobs/create_directory/
+        -k http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %><% ctx(job_status_url) %>create_directory/
         -H 'apikey: ***********'
     next:
       - when: <% succeeded() %>
@@ -166,7 +166,7 @@ tasks:
         "source_directory": "<% ctx(analysis_folder_path) %>",
         "destination_directory": "<% ctx(outbox_folder) %>",
         "filter": <% json_dump(ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('outbox_files_and_folders', []))%>,
-        "may_exist_filter": <% json_dump(ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('outbox_files_and_folders_that_may_exist', [])) %> }' http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %>/api/1.0/jobs/sync_directory/
+        "may_exist_filter": <% json_dump(ctx(process_settings).get(ctx(workpackage)).get(ctx(analysis)).get('outbox_files_and_folders_that_may_exist', [])) %> }' http://<% ctx(process_host_url) %>:<% ctx(process_host_gateway_port) %><% ctx(job_status_url) %>sync_directory/
     next:
       - when: <% succeeded() %>
         publish: sync_status_url=<% concat("http://",ctx(process_host_url),":",ctx(process_host_gateway_port),ctx(job_status_url),result().stdout.link.split("/")[-1]) %>

--- a/config.scheme.yaml
+++ b/config.scheme.yaml
@@ -288,3 +288,25 @@
     type: string
     required: true
     default: "10801"
+
+  #Miarka specific variables
+  job_status_url: 
+    description: The url to the job-endpoint on miarka-processing-service.
+    type: string
+    required: true
+    default: "/analysis_service/api/1.0/jobs/"
+  process_host_proj_path:
+    description: Parent dir to outbox, inbox and analysis.
+    type: string
+    required: true
+    default: "/proj/ngi2024001/nobackup/"
+  process_host_url:
+    description: Url to host running processing-service
+    type: string
+    required: true
+    default: "miarka1.uppmax.uu.se"
+  process_host_gateway_port:
+    description: Port to Kong-gateway
+    type: string
+    required: true
+    default: "9999"


### PR DESCRIPTION
Communication with miarka-processing-service from stackstorm is handle through a Kong-gateway running on Miarka. When a service endpoint is called the url to check job status is returned. However, the url is returned from the service perspective that has no contact with the world outside miarka. The service is running on localhost.

To be able to curl the job status we need to rewrite the returned link so it can be passed on to Kong, i.e. using the same url as when we first submit a job.