### PR TITLE
fix: Remove rsync wrapper from download miarka

### DIFF
--- a/actions/workflows/copy_data_to_miarka_for_processing.yaml
+++ b/actions/workflows/copy_data_to_miarka_for_processing.yaml
@@ -131,9 +131,6 @@ tasks:
   transfer_staging_dir:
      action: core.local
      input:
-       cwd: <% ctx(hospital_upload_staging_path) %>
-#       cmd: rsync.py -c -f "<% item() %>" -t <% ctx(upload_path) %>/fastq/ -u <% ctx(transfer_user) %> -i <% ctx(transfer_key) %> -r <% ctx(transfer_to_host) %> -p 2
-       # TODO:Convert to using rsync script above, but need to add support for realtive path (-R)?
        cmd:  "rsync -vcrRL -e 'ssh -i <% ctx(miarka_upload_key) %>'  ./.<% ctx(upload_path) %> <%  ctx(miarka_upload_user) %>@<% ctx(miarka_upload_host) %>:<% ctx(miarka_upload_path_prefix) %>"
        timeout: 86400
      next:

--- a/actions/workflows/copy_data_to_miarka_for_processing.yaml
+++ b/actions/workflows/copy_data_to_miarka_for_processing.yaml
@@ -131,6 +131,7 @@ tasks:
   transfer_staging_dir:
      action: core.local
      input:
+       cwd: <% ctx(hospital_upload_staging_path) %>
        cmd:  "rsync -vcrRL -e 'ssh -i <% ctx(miarka_upload_key) %>'  ./.<% ctx(upload_path) %> <%  ctx(miarka_upload_user) %>@<% ctx(miarka_upload_host) %>:<% ctx(miarka_upload_path_prefix) %>"
        timeout: 86400
      next:

--- a/actions/workflows/retrieve_result_wp_miarka.yaml
+++ b/actions/workflows/retrieve_result_wp_miarka.yaml
@@ -91,7 +91,7 @@ tasks:
     action: core.local
     input:
       timeout: 86400
-      cmd: rsync.py -c -f <% ctx(miarka_download_path_prefix) %>/<% ctx(workpackage) %>_<% ctx(analysis) %>/<% ctx(analysis_name) %>/ -t <% ctx(result_storage_folder) %>/<% ctx(analysis_name_result) %> -u <% ctx(miarka_download_user) %> -i <% ctx(miarka_download_key) %> -r <% ctx(miarka_download_host) %> -p 1
+      cmd:  "rsync -vcrRL -e 'ssh -i <% ctx(miarka_download_key) %>'  <%  ctx(miarka_download_user) %>@<% ctx(miarka_download_host) %>:<% ctx(miarka_download_path_prefix) %>/<% ctx(workpackage) %>_<% ctx(analysis) %>/<% ctx(analysis_name) %>/ <% ctx(result_storage_folder) %>/<% ctx(analysis_name_result) %>"
     retry:
       delay: 10
       count: 5
@@ -105,7 +105,7 @@ tasks:
           - create_qc_year_folder
       - when: <% failed() %>
         publish:
-          - stderr: "The transfer of fastq files from compute to hospital failed."
+          - stderr: "The transfer of result files from compute to hospital failed."
           - failed_step: 'transfer_result  -- Could not fetch result from <% ctx(miarka_download_host) %>\:<% ctx(analysis_name) %>, <% result() %>'
         do:
           - bioinfo_error_notifier


### PR DESCRIPTION
The rsync.py (python wrapper to rsync) currently used when retrieving analysis results back from miarka is not working in this setting. Before starting the actual rsync command the wrapper is trying to establish an ssh connection with the remote host (miarka in this case) with ssh -oBatchMode=yes. However, only rsync commands are allowed in this  case and the connection check will therefore fail and the transfer of data will nerver be started.

In this PR the use of the wrapper rsync.py is removed and the corresponding rsync-command is used directly in core.local.